### PR TITLE
Tooltip styles for ember-simple-charts

### DIFF
--- a/tests/dummy/app/styles/_variables.scss
+++ b/tests/dummy/app/styles/_variables.scss
@@ -1,12 +1,25 @@
 //default properties
-$gray: #f2f5f6;
 $brown: #a52a2a;
-$steelblue: #4682b4;
-$white: #fff;
 $black: #000;
 $charcoal: #334750;
+$gray: #f2f5f6;
+$background-grey: #fbfbfb;
+$base-border-color: $background-grey;
+$dark-grey: #aaa;
+$steelblue: #4682b4;
+$text-grey: #333;
+$white: #fff;
 
 
 // Font Sizes
 $base-font-size: 1em;
+$base-spacing: 1.5em;
+$h1-font-size: $base-font-size * 2.25;
+$h2-font-size: $base-font-size * 2;
+$h3-font-size: $base-font-size * 1.75;
+$h4-font-size: $base-font-size * 1.5;
+$h5-font-size: $base-font-size * 1.25;
+$h6-font-size: $base-font-size;
+
 $base-line-height: 1.5;
+$base-border-radius: 3px;

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,2 +1,3 @@
 @import 'variables';
 @import 'components/simple-charts';
+@import 'components/simple-charts-tooltip';

--- a/tests/dummy/app/styles/components/simple-charts-tooltip.scss
+++ b/tests/dummy/app/styles/components/simple-charts-tooltip.scss
@@ -1,0 +1,37 @@
+.simple-chart-tooltip {
+  background: $background-grey;
+  border: 1px solid $dark-grey;
+  border-radius: 15px;
+  box-shadow: 4px 4px 12px $dark-grey;
+  color: $text-grey;
+  font-size: $base-font-size;
+  line-height: $base-line-height;
+  margin: 0;
+  opacity: .9;
+  overflow: auto;
+  padding: 10px;
+  position: absolute;
+  width: 380px;
+
+  .header {
+    border-bottom: 1px solid $dark-grey;
+    font-size: $h6-font-size;
+    line-height: $base-line-height;
+
+    .title {
+      font-weight: 500;
+    }
+
+    .attr {
+      font-style: italic;
+      left: 340px;
+      position: absolute;
+      top: 26px;
+    }
+  }
+
+  .content {
+    font-size: .9 * $base-font-size;
+    margin: 10px 0 0;
+  }
+}


### PR DESCRIPTION
Added CSS for tooltip styling. We will need to add this to the ilios/frontend repo.