### PR TITLE
Ignore rejected promises

### DIFF
--- a/addon/components/simple-chart.js
+++ b/addon/components/simple-chart.js
@@ -18,28 +18,40 @@ export default Component.extend({
     async handleHover(data, tooltipTarget) {
       const hover = get(this, 'hover');
       if (hover) {
-        await hover(data);
-        if ( !(get(this, 'isDestroyed') || get(this, 'isDestroying')) ) {
-          set(this, 'tooltipTarget', tooltipTarget);
+        try {
+          await hover(data);
+          if ( !(get(this, 'isDestroyed') || get(this, 'isDestroying')) ) {
+            set(this, 'tooltipTarget', tooltipTarget);
+          }
+        } catch (e) {
+          //we will just ignore errors here since the mouse state is transient
         }
       }
     },
     async handleLeave() {
       const leave = get(this, 'leave');
       if (leave) {
-        await leave();
-      }
-      if ( !(get(this, 'isDestroyed') || get(this, 'isDestroying')) ) {
-        set(this, 'tooltipTarget', null);
+        try {
+          await leave();
+          if ( !(get(this, 'isDestroyed') || get(this, 'isDestroying')) ) {
+            set(this, 'tooltipTarget', null);
+          }
+        } catch (e) {
+          //we will just ignore errors here since the mouse state is transient
+        }
       }
     },
     async handleClick(data) {
       const click = get(this, 'click');
       if (click) {
-        await click(data);
-      }
-      if ( !(get(this, 'isDestroyed') || get(this, 'isDestroying')) ) {
-        set(this, 'tooltipTarget', null);
+        try {
+          await click(data);
+          if ( !(get(this, 'isDestroyed') || get(this, 'isDestroying')) ) {
+            set(this, 'tooltipTarget', null);
+          }
+        } catch (e) {
+          //we will just ignore errors here since the mouse state is transient
+        }
       }
     },
   }


### PR DESCRIPTION
When we're working with transient mouse events promises are rejected
when a task is canceled and I think we can safely ignore these issues.