### PR TITLE
Lock our ember-d3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-sass": "^7.1.2",
     "ember-concurrency": "^0.8.17",
-    "ember-d3": "^0.4.3",
+    "ember-d3": "0.4.3",
     "ember-modal-dialog": "^2.4.1",
     "ember-resize-aware": "^1.0.0",
     "ember-tether": "v0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3042,7 +3042,7 @@ ember-concurrency@^0.8.17:
     ember-cli-babel "^6.8.2"
     ember-maybe-import-regenerator "^0.1.5"
 
-ember-d3@^0.4.3:
+ember-d3@0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/ember-d3/-/ember-d3-0.4.3.tgz#3025897ec6a294cd4c6763e91c2e30a78a0ecb7e"
   dependencies:


### PR DESCRIPTION
The latest ember-d3 has trouble being used as an addon dependency. Until
that is resolved let's stick with the previous version.