### PR TITLE
Don't let ember-concurrency float

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-cli-babel": "^6.8.1",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-sass": "^7.1.2",
-    "ember-concurrency": "^0.8.17",
+    "ember-concurrency": "0.8.18",
     "ember-d3": "0.4.3",
     "ember-modal-dialog": "^2.4.1",
     "ember-resize-aware": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2796,9 +2796,9 @@ ember-cli@2.18.2:
     walk-sync "^0.3.0"
     yam "0.0.22"
 
-ember-concurrency@^0.8.17:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.17.tgz#be47a90342f1960f4f57284c2fe5f7ce2396142a"
+ember-concurrency@0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.18.tgz#20a9ac4ced6496ea4ebe52e88f4524a473871396"
   dependencies:
     babel-core "^6.24.1"
     ember-cli-babel "^6.8.2"


### PR DESCRIPTION
This has caused us issues with the dependency linter in the past.