### PR TITLE
Improve visual tests

### DIFF
--- a/addon/components/simple-chart-donut.js
+++ b/addon/components/simple-chart-donut.js
@@ -30,6 +30,8 @@ export default Component.extend(ChartProperties, {
     const color = scaleSequential(interpolateSinebow).domain([0, Math.max(...values)]);
     const donutWidth = width * .2;
 
+    this.element.classList.add('loading');
+
     let createArc = arc().innerRadius(radius - donutWidth).outerRadius(radius);
     let createPie = pie().value(d => d.data).sort(null);
     let createLabelArc = arc().outerRadius(radius - 32).innerRadius(radius - 32);
@@ -54,6 +56,10 @@ export default Component.extend(ChartProperties, {
         b.innerRadius = 0;
         const i = interpolate({startAngle: 0, endAngle: 0}, b);
         return (p) => createArc(i(p));
+      }).on('end', () => {
+        if (this.element) {
+          this.element.classList.replace('loading', 'loaded');
+        }
       });
 
     if (!isIcon) {

--- a/addon/components/simple-chart-pie.js
+++ b/addon/components/simple-chart-pie.js
@@ -29,6 +29,8 @@ export default Component.extend(ChartProperties, {
     const values = A(dataOrArray).mapBy('data');
     const color = scaleSequential(interpolateSinebow).domain([0, Math.max(...values)]);
 
+    this.element.classList.add('loading');
+
     let createArc = arc().innerRadius(0).outerRadius(radius);
     let createPie = pie().value(d => d.data).sort(null);
     let createLabelArc = arc().outerRadius(radius - 32).innerRadius(radius - 32);
@@ -53,6 +55,10 @@ export default Component.extend(ChartProperties, {
         b.innerRadius = 0;
         const i = interpolate({startAngle: 0, endAngle: 0}, b);
         return (p) => createArc(i(p));
+      }).on('end', () => {
+        if (this.element) {
+          this.element.classList.replace('loading', 'loaded');
+        }
       });
 
     if (!isIcon) {

--- a/tests/acceptance/rendered-charts-test.js
+++ b/tests/acceptance/rendered-charts-test.js
@@ -1,10 +1,11 @@
-import { later } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   settled,
   click,
   currentURL,
+  findAll,
+  waitUntil,
   visit
 } from '@ember/test-helpers';
 import { percySnapshot } from 'ember-percy';
@@ -15,44 +16,49 @@ module('Acceptance | rendered charts', function(hooks) {
   test('visiting /', async function (assert) {
     await visit('/');
     const charts = '.ember-simple-charts-wrapper .panel';
+    const loaded = '.loaded';
     assert.equal(currentURL(), '/');
     assert.dom(charts).exists({ count: 7 });
 
-
     //let the chart animations finish
-    later(async () => {
-      await percySnapshot(assert);
-    }, 1000);
+    await waitUntil(() => {
+      return findAll(loaded).length >= 2;
+    });
+    await percySnapshot(assert);
     await settled();
   });
 
   test('visiting donut chart', async function (assert) {
     await visit('/');
     const charts = '.ember-simple-charts-wrapper .panel';
+    const loaded = '.loaded';
     const link = `${charts}:nth-of-type(1) a`;
 
     await click(link);
     assert.equal(currentURL(), '/chart-donut');
 
     //let the chart animations finish
-    later(async () => {
-      await percySnapshot(assert);
-    }, 1000);
+    await waitUntil(() => {
+      return findAll(loaded).length >= 4;
+    });
+    await percySnapshot(assert);
     await settled();
   });
 
   test('visiting pie chart', async function (assert) {
     await visit('/');
     const charts = '.ember-simple-charts-wrapper .panel';
+    const loaded = '.loaded';
     const link = `${charts}:nth-of-type(2) a`;
 
     await click(link);
     assert.equal(currentURL(), '/chart-pie');
 
     //let the chart animations finish
-    later(async () => {
-      await percySnapshot(assert);
-    }, 1000);
+    await waitUntil(() => {
+      return findAll(loaded).length >= 3;
+    });
+    await percySnapshot(assert);
     await settled();
   });
 
@@ -65,9 +71,10 @@ module('Acceptance | rendered charts', function(hooks) {
     assert.equal(currentURL(), '/chart-bar');
 
     //let the chart animations finish
-    later(async () => {
-      await percySnapshot(assert);
-    }, 1000);
+    await waitUntil(() => {
+      return findAll('.simple-chart').length >= 3;
+    });
+    await percySnapshot(assert);
     await settled();
   });
 
@@ -80,9 +87,10 @@ module('Acceptance | rendered charts', function(hooks) {
     assert.equal(currentURL(), '/chart-horz-bar');
 
     //let the chart animations finish
-    later(async () => {
-      await percySnapshot(assert);
-    }, 1000);
+    await waitUntil(() => {
+      return findAll('.simple-chart').length >= 3;
+    });
+    await percySnapshot(assert);
     await settled();
   });
 
@@ -95,9 +103,10 @@ module('Acceptance | rendered charts', function(hooks) {
     assert.equal(currentURL(), '/chart-cluster');
 
     //let the chart animations finish
-    later(async () => {
-      await percySnapshot(assert);
-    }, 1000);
+    await waitUntil(() => {
+      return findAll('.simple-chart').length >= 3;
+    });
+    await percySnapshot(assert);
     await settled();
   });
 
@@ -110,9 +119,10 @@ module('Acceptance | rendered charts', function(hooks) {
     assert.equal(currentURL(), '/chart-pack');
 
     //let the chart animations finish
-    later(async () => {
-      await percySnapshot(assert);
-    }, 1000);
+    await waitUntil(() => {
+      return findAll('.simple-chart').length >= 3;
+    });
+    await percySnapshot(assert);
     await settled();
   });
 
@@ -125,9 +135,10 @@ module('Acceptance | rendered charts', function(hooks) {
     assert.equal(currentURL(), '/chart-tree');
 
     //let the chart animations finish
-    later(async () => {
-      await percySnapshot(assert);
-    }, 1000);
+    await waitUntil(() => {
+      return findAll('.simple-chart').length >= 3;
+    });
+    await percySnapshot(assert);
     await settled();
   });
 });

--- a/tests/integration/components/simple-chart-donut-test.js
+++ b/tests/integration/components/simple-chart-donut-test.js
@@ -1,7 +1,6 @@
-import { later } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, find } from '@ember/test-helpers';
+import { render, settled, find, findAll, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ChartData from 'dummy/lib/chart-data';
 import { percySnapshot } from 'ember-percy';
@@ -12,12 +11,17 @@ module('Integration | Component | simple chart donut', function(hooks) {
   test('it renders', async function (assert) {
     this.set('chartData', ChartData);
     const svg = 'svg';
+    const loaded = '.loaded';
     await render(hbs`{{simple-chart-donut data=chartData.donut}}`);
-    later(() => {
-      percySnapshot(assert);
-      assert.equal(find(svg).getAttribute('height'), '100%');
-      assert.equal(find(svg).getAttribute('width'), '100%');
-    }, 1000);
+
+    //let the chart animations finish
+    await waitUntil(() => {
+      return findAll(loaded).length;
+    });
+
+    percySnapshot(assert);
+    assert.equal(find(svg).getAttribute('height'), '100%');
+    assert.equal(find(svg).getAttribute('width'), '100%');
 
     await settled();
   });

--- a/tests/integration/components/simple-chart-pie-test.js
+++ b/tests/integration/components/simple-chart-pie-test.js
@@ -1,7 +1,6 @@
-import { later } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, find } from '@ember/test-helpers';
+import { render, settled, find, findAll, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ChartData from 'dummy/lib/chart-data';
 import { percySnapshot } from 'ember-percy';
@@ -12,13 +11,20 @@ module('Integration | Component | simple chart pie', function(hooks) {
   test('it renders', async function (assert) {
     this.set('chartData', ChartData);
     const svg = 'svg';
+    const loaded = '.loaded';
     await render(hbs`{{simple-chart-pie data=chartData.pie}}`);
-    later(() => {
-      percySnapshot(assert);
 
-      assert.equal(find(svg).getAttribute('height'), '100%');
-      assert.equal(find(svg).getAttribute('width'), '100%');
-    }, 1000);
+
+
+    //let the chart animations finish
+    await waitUntil(() => {
+      return findAll(loaded).length;
+    });
+
+    percySnapshot(assert);
+
+    assert.equal(find(svg).getAttribute('height'), '100%');
+    assert.equal(find(svg).getAttribute('width'), '100%');
 
     await settled();
   });


### PR DESCRIPTION
Waiting for a fixed length of time wasn't working, sometimes the percy
test captured a partially loaded state, this should be a bit more
reliable.