### PR TITLE
Calculate text color based on chart color

### DIFF
--- a/addon/components/simple-chart-bar.js
+++ b/addon/components/simple-chart-bar.js
@@ -43,12 +43,23 @@ export default Component.extend(ChartProperties, {
       .attr('height', d => `${yScale(d.data)}%`)
       .attr('x', d => `${xScale(d.label)}%`)
       .attr('y', d => `${100 - yScale(d.data)}%`)
-      .attr('fill', d =>  color(d.label));
+      .attr('fill', d =>  color(d.data));
 
     if (!isIcon) {
       const text = bars.selectAll('text').data(dataOrArray).enter()
         .append("text")
-        .attr("fill", "#ffffff")
+        .style("color", d => {
+          const rgb = color(d.data);
+          //cut up rgb(1, 99, 245) into parts
+          const parts = rgb.substr(4).split(')')[0].split(',');
+          const r = parseInt(parts[0], 16);
+          const g = parseInt(parts[1], 16);
+          const b = parseInt(parts[2], 16);
+          //Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
+          const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+
+          return (yiq >= 256) ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
+        })
         .style("font-size", ".8rem")
         .attr("text-anchor", "middle")
         .attr('x', d => `${xScale(d.label	) + xScale.bandwidth() / 2}%`)

--- a/addon/components/simple-chart-donut.js
+++ b/addon/components/simple-chart-donut.js
@@ -65,7 +65,18 @@ export default Component.extend(ChartProperties, {
     if (!isIcon) {
       const text = chart.selectAll('.slice')
         .append("text")
-        .attr("fill", "#ffffff")
+        .style("color", d => {
+          const rgb = color(d.data.data);
+          //cut up rgb(1, 99, 245) into parts
+          const parts = rgb.substr(4).split(')')[0].split(',');
+          const r = parseInt(parts[0], 16);
+          const g = parseInt(parts[1], 16);
+          const b = parseInt(parts[2], 16);
+          //Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
+          const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+
+          return (yiq >= 256) ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
+        })
         .style("font-size", ".8rem")
         .attr('transform', d => "translate(" + createLabelArc.centroid(d) + ")")
         .attr("dy", ".40rem")

--- a/addon/components/simple-chart-horz-bar.js
+++ b/addon/components/simple-chart-horz-bar.js
@@ -48,7 +48,18 @@ export default Component.extend(ChartProperties, {
     if (!isIcon) {
       const text = bars.selectAll('text').data(dataOrArray).enter()
         .append("text")
-        .attr("fill", "#ffffff")
+        .style("color", d => {
+          const rgb = color(d.data);
+          //cut up rgb(1, 99, 245) into parts
+          const parts = rgb.substr(4).split(')')[0].split(',');
+          const r = parseInt(parts[0], 16);
+          const g = parseInt(parts[1], 16);
+          const b = parseInt(parts[2], 16);
+          //Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
+          const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+
+          return (yiq >= 256) ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
+        })
         .style("font-size", ".8rem")
         .attr("text-anchor", "end")
         .attr("text-align", "right")

--- a/addon/components/simple-chart-pie.js
+++ b/addon/components/simple-chart-pie.js
@@ -64,7 +64,18 @@ export default Component.extend(ChartProperties, {
     if (!isIcon) {
       const text = chart.selectAll('.slice')
         .append("text")
-        .attr("fill", "#ffffff")
+        .style("color", d => {
+          const rgb = color(d.data.data);
+          //cut up rgb(1, 99, 245) into parts
+          const parts = rgb.substr(4).split(')')[0].split(',');
+          const r = parseInt(parts[0], 16);
+          const g = parseInt(parts[1], 16);
+          const b = parseInt(parts[2], 16);
+          //Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
+          const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+
+          return (yiq >= 256) ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
+        })
         .style("font-size", ".8rem")
         .attr('transform', d => "translate(" + createLabelArc.centroid(d) + ")")
         .attr("dy", ".40rem")

--- a/tests/integration/components/simple-chart-bar-test.js
+++ b/tests/integration/components/simple-chart-bar-test.js
@@ -17,6 +17,12 @@ module('Integration | Component | simple chart bar', function(hooks) {
     const rect3 = `${shapes}:nth-of-type(3)`;
     const rect4 = `${shapes}:nth-of-type(4)`;
 
+    const text = `${svg} .bars text`;
+    const text1 = `${text}:nth-of-type(1)`;
+    const text2 = `${text}:nth-of-type(2)`;
+    const text3 = `${text}:nth-of-type(3)`;
+    const text4 = `${text}:nth-of-type(4)`;
+
     await render(hbs`{{simple-chart-bar data=chartData.bar}}`);
     percySnapshot(assert);
 
@@ -27,5 +33,19 @@ module('Integration | Component | simple chart bar', function(hooks) {
     assert.equal(find(rect2).getAttribute('y'), '62%');
     assert.equal(find(rect3).getAttribute('y'), '24%');
     assert.equal(find(rect4).getAttribute('y'), '5%');
+    assert.equal(find(rect1).getAttribute('fill'), 'rgb(24, 114, 244)');
+    assert.equal(find(rect2).getAttribute('fill'), 'rgb(24, 244, 114)');
+    assert.equal(find(rect3).getAttribute('fill'), 'rgb(167, 3, 213)');
+    assert.equal(find(rect4).getAttribute('fill'), 'rgb(255, 64, 64)');
+
+    assert.equal(findAll(text).length, 4);
+    assert.equal(find(text1).textContent, '300');
+    assert.equal(find(text2).textContent, '200');
+    assert.equal(find(text3).textContent, '400');
+    assert.equal(find(text4).textContent, '500');
+    assert.ok(find(text1).getAttribute('style').includes('color: rgb(255, 255, 255);'));
+    assert.ok(find(text2).getAttribute('style').includes('color: rgb(0, 0, 0);'));
+    assert.ok(find(text3).getAttribute('style').includes('color: rgb(255, 255, 255);'));
+    assert.ok(find(text4).getAttribute('style').includes('color: rgb(255, 255, 255);'));
   });
 });

--- a/tests/integration/components/simple-chart-horz-bar-test.js
+++ b/tests/integration/components/simple-chart-horz-bar-test.js
@@ -19,6 +19,14 @@ module('Integration | Component | simple chart horz bar', function(hooks) {
     const rect5 = `${shapes}:nth-of-type(5)`;
     const rect6 = `${shapes}:nth-of-type(6)`;
     const rect7 = `${shapes}:nth-of-type(7)`;
+    const text = `${svg} .bars text`;
+    const text1 = `${text}:nth-of-type(1)`;
+    const text2 = `${text}:nth-of-type(2)`;
+    const text3 = `${text}:nth-of-type(3)`;
+    const text4 = `${text}:nth-of-type(4)`;
+    const text5 = `${text}:nth-of-type(5)`;
+    const text6 = `${text}:nth-of-type(6)`;
+    const text7 = `${text}:nth-of-type(7)`;
 
     await render(hbs`{{simple-chart-horz-bar data=chartData.horz}}`);
     percySnapshot(assert);
@@ -33,6 +41,28 @@ module('Integration | Component | simple chart horz bar', function(hooks) {
     assert.equal(find(rect5).getAttribute('width'), '27.142857142857142%');
     assert.equal(find(rect6).getAttribute('width'), '54.285714285714285%');
     assert.equal(find(rect7).getAttribute('width'), '95%');
+
+    assert.equal(find(rect1).getAttribute('fill'), 'rgb(13, 233, 137)');
+    assert.equal(find(rect2).getAttribute('fill'), 'rgb(13, 137, 233)');
+    assert.equal(find(rect3).getAttribute('fill'), 'rgb(207, 1, 174)');
+    assert.equal(find(rect4).getAttribute('fill'), 'rgb(255, 64, 64)');
+    assert.equal(find(rect5).getAttribute('fill'), 'rgb(99, 249, 34)');
+    assert.equal(find(rect6).getAttribute('fill'), 'rgb(13, 137, 233)');
+    assert.equal(find(rect7).getAttribute('fill'), 'rgb(255, 64, 64)');
+    assert.equal(find(text1).textContent, 'Mark');
+    assert.equal(find(text2).textContent, 'John');
+    assert.equal(find(text3).textContent, 'Kathy');
+    assert.equal(find(text4).textContent, 'Jeff Long Namerson');
+    assert.equal(find(text5).textContent, 'Joe');
+    assert.equal(find(text6).textContent, 'Kelly');
+    assert.equal(find(text7).textContent, 'Jason');
+    assert.ok(find(text1).getAttribute('style').includes('color: rgb(0, 0, 0)'));
+    assert.ok(find(text2).getAttribute('style').includes('color: rgb(255, 255, 255)'));
+    assert.ok(find(text3).getAttribute('style').includes('color: rgb(255, 255, 255)'));
+    assert.ok(find(text4).getAttribute('style').includes('color: rgb(255, 255, 255)'));
+    assert.ok(find(text5).getAttribute('style').includes('color: rgb(0, 0, 0)'));
+    assert.ok(find(text6).getAttribute('style').includes('color: rgb(255, 255, 255)'));
+    assert.ok(find(text7).getAttribute('style').includes('color: rgb(255, 255, 255)'));
 
   });
 });


### PR DESCRIPTION
Chooses either a white or black color for chart labels automatically
based on the color of the chart element they overlay.