### PR TITLE
Disable percy without sending requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ branches:
 jobs:
   fail_fast: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary PERCY_TOKEN=false
+    - env: EMBER_TRY_SCENARIO=ember-canary PERCY_TOKEN=''
 
   include:
     # runs linting and tests with current locked deps
@@ -45,10 +45,10 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-3.13 PERCY_TOKEN=false
-    - env: EMBER_TRY_SCENARIO=ember-release PERCY_TOKEN=false
-    - env: EMBER_TRY_SCENARIO=ember-beta PERCY_TOKEN=false
-    - env: EMBER_TRY_SCENARIO=ember-canary PERCY_TOKEN=false
+      env: EMBER_TRY_SCENARIO=ember-3.13 PERCY_TOKEN=''
+    - env: EMBER_TRY_SCENARIO=ember-release PERCY_TOKEN=''
+    - env: EMBER_TRY_SCENARIO=ember-beta PERCY_TOKEN=''
+    - env: EMBER_TRY_SCENARIO=ember-canary PERCY_TOKEN=''
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO


### PR DESCRIPTION
Setting this to false just ends up being a string so requests still get
sent to the API. Setting it to an empty string disables the integration
so we don't hit up percy with a bad token.