### PR TITLE
Fix percy test for donut chart

### DIFF
--- a/tests/acceptance/rendered-charts-test.js
+++ b/tests/acceptance/rendered-charts-test.js
@@ -37,6 +37,7 @@ module('Acceptance | rendered charts', function(hooks) {
 
     await click(link);
     assert.equal(currentURL(), '/docs/donut');
+    await chartsLoaded();
     await percySnapshot(assert);
     await settled();
   });
@@ -47,7 +48,8 @@ module('Acceptance | rendered charts', function(hooks) {
     const link = `${charts}:nth-of-type(2) a`;
 
     await click(link);
-    assert.equal(currentURL(), '/docs/pie');    await chartsLoaded();
+    assert.equal(currentURL(), '/docs/pie');
+    await chartsLoaded();
     await percySnapshot(assert);
     await settled();
   });


### PR DESCRIPTION
Missing wait here that ensures all the animations have finished before
taking a snapshot.