### PR TITLE
Add Percy Token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: test
       run: npm test
       env:
-        PERCY_TOKEN: ${{secrets.percy_token}}
+        PERCY_TOKEN: 700b60c059079e8ff4431ae83c9406ed4b199bce7ab700ab26a77b5273a5d339
 
   test-floating:
     name: Floating Dependencies


### PR DESCRIPTION
This is a write only token so barring malicious annoyance all someone
can do with it is use up our build minutes for the month. Putting it
directly in the workflow allows snapshots to work on pull requests from
forks as well as branches.