### PR TITLE
Drop node 8 in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 8
+        node-version: 10
     - name: install dependencies
       run: npm ci
     - name: lint js
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
     needs: test
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/future-ci.yaml
+++ b/.github/workflows/future-ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
We dropped support a while ago, but didn't update tests.