### PR TITLE
Fix svg styles

### DIFF
--- a/addon/styles/components/simple-chart.scss
+++ b/addon/styles/components/simple-chart.scss
@@ -4,6 +4,7 @@
   width: 100%;
 
   svg {
+    display: block;
     text {
       cursor: default;
       font-size: .8 * $base-font-size;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4316,7 +4316,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-3.0.3.tgz",
       "integrity": "sha1-C9LJapc41qarWQ8HujXFFX19tHY=",
-      "dev": true,
       "requires": {
         "broccoli-kitchen-sink-helpers": "^0.3.1",
         "broccoli-plugin": "^1.2.1",
@@ -4330,7 +4329,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4338,14 +4336,12 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -4353,8 +4349,7 @@
         "rsvp": {
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
         }
       }
     },
@@ -4889,7 +4884,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-4.0.0.tgz",
       "integrity": "sha512-Bjgg0Q626pPwiPU+Sk7jJNjblPEwhceuTzMPw2F5XY+FzdTBMYQKuJYlJ4x2DdsubE95e3rVQeSZ68jA13Nhzg==",
-      "dev": true,
       "requires": {
         "broccoli-caching-writer": "^3.0.3",
         "include-path-searcher": "^0.1.0",
@@ -4901,20 +4895,17 @@
         "mkdirp": {
           "version": "0.3.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
         },
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
         },
         "rsvp": {
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
         }
       }
     },
@@ -7176,9 +7167,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.686",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.686.tgz",
-      "integrity": "sha512-SOJT3m00NX/gT3sD6E3PcZX6u3+zUmQq4+yp8QCKLOwf2ECnmh9eAY+eonhC/AAu5Gg2WrtUU2m7/+e85O0l6A=="
+      "version": "1.3.687",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
+      "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ=="
     },
     "element-resize-detector": {
       "version": "1.2.2",
@@ -8359,7 +8350,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
       "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
-      "dev": true,
       "requires": {
         "broccoli-funnel": "^2.0.1",
         "broccoli-merge-trees": "^3.0.1",
@@ -8371,7 +8361,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -12875,8 +12864,7 @@
     "include-path-searcher": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/include-path-searcher/-/include-path-searcher-0.1.0.tgz",
-      "integrity": "sha1-wM8t36Fk+y6uB7x8pDp/GRy0170=",
-      "dev": true
+      "integrity": "sha1-wM8t36Fk+y6uB7x8pDp/GRy0170="
     },
     "indent-string": {
       "version": "4.0.0",
@@ -19154,9 +19142,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
-      "integrity": "sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.1.tgz",
+      "integrity": "sha512-EWhx3fHy3M9JbaeTnO+rEqzCe1wtyQClv6q3YWq0voOj4E+bMZBErVS1GAHPDiRGONYq34M1/d8KuQMgvi6Gjw==",
       "optional": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-auto-import": "^1.10.1",
     "ember-cli-babel": "^7.23.1",
     "ember-cli-htmlbars": "^5.3.2",
+    "ember-cli-sass": "^10.0.0",
     "ember-concurrency": "^2.0.0",
     "ember-did-resize-modifier": "^1.0.0",
     "ember-in-element-polyfill": "^1.0.0"
@@ -61,7 +62,6 @@
     "ember-cli": "~3.25.2",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
-    "ember-cli-sass": "^10.0.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
     "ember-disable-prototype-extensions": "^1.1.3",


### PR DESCRIPTION
Correcting two issues here:
1) We need ember-cli-sass to be a dependency so it will bundle our css
into vendor.css to be consumed by apps.
2) There was a css reset in addon-docs that was setting our SVGs to
blocks. When that was moved into a sub-app we lost that style and needed
to apply it ourselves.