### PR TITLE
Set the working directory for this step only

### DIFF
--- a/.github/workflows/update-transitive-dependenies.yaml
+++ b/.github/workflows/update-transitive-dependenies.yaml
@@ -20,9 +20,7 @@ jobs:
         rm package-lock.json
         npm install
     - name: remove and re-create docs lock file
-      defaults:
-        run:
-          working-directory: docs
+      working-directory: docs
       run: |
         rm package-lock.json
         npm install


### PR DESCRIPTION
The defaults syntax is only for entire jobs, but we don't need that
here. Only this step is in the docs directory.