### PR TITLE
suppress destroyables API deprecation warnings

### DIFF
--- a/addon/components/simple-chart-donut.js
+++ b/addon/components/simple-chart-donut.js
@@ -2,7 +2,7 @@ import 'd3-transition';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-
+import { isDestroying, isDestroyed } from '@ember/destroyable';
 import { select } from 'd3-selection';
 import { scaleSequential } from 'd3-scale';
 import { interpolateSinebow } from 'd3-scale-chromatic';
@@ -72,7 +72,7 @@ export default class SimpleChartDonut extends Component {
         return (p) => createArc(i(p));
       })
       .on('end', () => {
-        if (!(this.isDestroyed || this.isDestroying)) {
+        if (!(isDestroyed(this) || isDestroying(this))) {
           this.loading = false;
         }
       });

--- a/addon/components/simple-chart-pie.js
+++ b/addon/components/simple-chart-pie.js
@@ -1,8 +1,8 @@
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { isDestroying, isDestroyed } from '@ember/destroyable';
 import 'd3-transition';
-
 import { select } from 'd3-selection';
 import { scaleSequential } from 'd3-scale';
 import { interpolateSinebow } from 'd3-scale-chromatic';
@@ -69,7 +69,7 @@ export default class SimpleChartDonut extends Component {
         return (p) => createArc(i(p));
       })
       .on('end', () => {
-        if (!(this.isDestroyed || this.isDestroying)) {
+        if (!(isDestroyed(this) || isDestroying(this))) {
           this.loading = false;
         }
       });

--- a/addon/components/simple-chart.js
+++ b/addon/components/simple-chart.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { timeout, task, taskGroup, restartableTask } from 'ember-concurrency';
+import { isDestroying, isDestroyed } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { ensureSafeComponent } from '@embroider/util';
@@ -56,7 +57,7 @@ export default class SimpleChart extends Component {
     if (this.args.hover) {
       try {
         yield this.args.hover(data);
-        if (!(this.isDestroyed || this.isDestroying)) {
+        if (!(isDestroyed(this) || isDestroying(this))) {
           this.tooltipTarget = tooltipTarget;
         }
       } catch (e) {
@@ -70,7 +71,7 @@ export default class SimpleChart extends Component {
     if (this.args.leave) {
       try {
         yield this.args.leave();
-        if (!(this.isDestroyed || this.isDestroying)) {
+        if (!(isDestroyed(this) || isDestroying(this))) {
           this.tooltipTarget = null;
         }
       } catch (e) {
@@ -83,7 +84,7 @@ export default class SimpleChart extends Component {
     if (this.args.onClick) {
       try {
         yield this.args.onClick(data);
-        if (!(this.isDestroyed || this.isDestroying)) {
+        if (!(isDestroyed(this) || isDestroying(this))) {
           this.tooltipTarget = null;
         }
       } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "d3-transition": "^3.0.0",
         "ember-auto-import": "^2.2.4",
         "ember-cli-babel": "^7.26.6",
+        "ember-cli-deprecation-workflow": "^2.1.0",
         "ember-cli-htmlbars": "^6.0.0",
         "ember-cli-sass": "^10.0.0",
         "ember-concurrency": "^2.0.0",
@@ -8480,6 +8481,274 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-2.1.0.tgz",
+      "integrity": "sha512-Ay9P9iKMJdY4Gq5XPowh3HqqeAzLfwBRj1oB1ZKkDW1fryZQWBN4pZuRnjnB+3VWZjBnZif5e7Pacc7YNW9hWg==",
+      "dependencies": {
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-plugin": "^4.0.5",
+        "ember-cli-htmlbars": "^5.3.2"
+      },
+      "engines": {
+        "node": "12.* || >= 14"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/async-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "^2.5.1",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/broccoli-funnel": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+      "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "broccoli-plugin": "^4.0.7",
+        "debug": "^4.1.1",
+        "fs-tree-diff": "^2.0.1",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "walk-sync": "^2.0.2"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/broccoli-merge-trees": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+      "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+      "dependencies": {
+        "broccoli-plugin": "^4.0.2",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/broccoli-persistent-filter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
+      "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+      "dependencies": {
+        "async-disk-cache": "^2.0.0",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^4.0.3",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/broccoli-persistent-filter/node_modules/promise-map-series": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+      "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+      "dependencies": {
+        "rsvp": "^3.0.14"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/broccoli-persistent-filter/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/broccoli-plugin": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+      "dependencies": {
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-output-wrapper": "^3.2.5",
+        "fs-merger": "^3.2.1",
+        "promise-map-series": "^0.3.0",
+        "quick-temp": "^0.1.8",
+        "rimraf": "^3.0.2",
+        "symlink-or-copy": "^1.3.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/editions": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "dependencies": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/editions/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/ember-cli-htmlbars": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
+      "dependencies": {
+        "@ember/edition-utils": "^1.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-persistent-filter": "^3.1.2",
+        "broccoli-plugin": "^4.0.3",
+        "common-tags": "^1.8.0",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "fs-tree-diff": "^2.0.1",
+        "hash-for-dep": "^1.5.1",
+        "heimdalljs-logger": "^0.1.10",
+        "json-stable-stringify": "^1.0.1",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1",
+        "strip-bom": "^4.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/ember-cli-version-checker": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+      "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+      "dependencies": {
+        "resolve-package-path": "^3.1.0",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/fs-tree-diff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+      "dependencies": {
+        "@types/symlink-or-copy": "^1.2.0",
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/istextorbinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+      "dependencies": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/matcher-collection": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/promise-map-series": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/sync-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.6",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-cli-get-component-path-option": {
@@ -24988,41 +25257,15 @@
       }
     },
     "@babel/plugin-proposal-decorators": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.17.9.tgz",
-      "integrity": "sha512-EfH2LZ/vPa2wuPwJ26j+kYRkaubf89UlwxKXtxqEm57HrgSEYDB8t4swFP+p8LcI9yiP9ZRJJjo/58hS6BnaDA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.17.8.tgz",
+      "integrity": "sha512-U69odN4Umyyx1xO1rTII0IDkAEC+RNlcKXtqOblfpzqy1C+aOplb76BQNq0+XdpVkOaPlpEDwd++joY8FNFJKA==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.17.9",
+        "@babel/helper-create-class-features-plugin": "^7.17.6",
         "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
         "@babel/plugin-syntax-decorators": "^7.17.0",
         "charcodes": "^0.2.0"
-      },
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": {
-          "version": "7.17.9",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz",
-          "integrity": "sha512-kUjip3gruz6AJKOq5i3nC6CoCEEF/oHH3cp6tOZhB+IyyyPyW0g1Gfsxn3mkk6S08pIA2y8GQh609v9G/5sHVQ==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.16.7",
-            "@babel/helper-environment-visitor": "^7.16.7",
-            "@babel/helper-function-name": "^7.17.9",
-            "@babel/helper-member-expression-to-functions": "^7.17.7",
-            "@babel/helper-optimise-call-expression": "^7.16.7",
-            "@babel/helper-replace-supers": "^7.16.7",
-            "@babel/helper-split-export-declaration": "^7.16.7"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.17.9",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-          "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
-          "requires": {
-            "@babel/template": "^7.16.7",
-            "@babel/types": "^7.17.0"
-          }
-        }
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
@@ -26152,9 +26395,9 @@
       }
     },
     "@embroider/test-setup": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-1.6.0.tgz",
-      "integrity": "sha512-6U+NsfGL9ubADreLCnOWMCVFpoU4/DzHlbgfEH3NE+rcdF+2WbY8VP+MeqjjccoES0HvhIeUKvoIbiqkoWAbhQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-1.5.0.tgz",
+      "integrity": "sha512-4C0dgVswxfA/lBCD8FUWADQhjeO8AJ2KmRkvItOPSwPlAA1QI7gOD28DuiAnCAK18muIFq7P++gvl1qBNid6lg==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",
@@ -26162,45 +26405,15 @@
       }
     },
     "@embroider/util": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.6.0.tgz",
-      "integrity": "sha512-oUQDAMiAATHsiNwEMH/SzNSQ/Z5wDr9f6NImsDIFLvDT6T34/p7cqR4wyfrfMRtcc1EB6PbwhZ6bXYsJ6QPWRA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.5.0.tgz",
+      "integrity": "sha512-CoE98WDnRtXPn8x8SJkWHGw7frikRIetpImwwC9qyse/AvSoOsS4B5U0G8omZLMvwm2IEc9NemlDrS4ZyUlJ/A==",
       "requires": {
-        "@embroider/macros": "1.6.0",
+        "@embroider/macros": "1.5.0",
         "broccoli-funnel": "^3.0.5",
         "ember-cli-babel": "^7.23.1"
       },
       "dependencies": {
-        "@embroider/macros": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.6.0.tgz",
-          "integrity": "sha512-yUEXJGJGP3rjtxorxrbkdxriBFEwnmzOrNk4zK64IXKBfyRjiDZFUHV9DSTrbaYLS29Mw5yK73ZIwi8L13C4Zw==",
-          "requires": {
-            "@embroider/shared-internals": "1.6.0",
-            "assert-never": "^1.2.1",
-            "babel-import-util": "^1.1.0",
-            "ember-cli-babel": "^7.26.6",
-            "find-up": "^5.0.0",
-            "lodash": "^4.17.21",
-            "resolve": "^1.20.0",
-            "semver": "^7.3.2"
-          }
-        },
-        "@embroider/shared-internals": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.6.0.tgz",
-          "integrity": "sha512-es7+pV2S9+tgX5T4losppheXfa+xWtKD6x0gq7mxqA4DIdE14mORNeSWM8/Fu9f/t0tJnPqttddbgnDYw+SvrA==",
-          "requires": {
-            "babel-import-util": "^1.1.0",
-            "ember-rfc176-data": "^0.3.17",
-            "fs-extra": "^9.1.0",
-            "js-string-escape": "^1.0.1",
-            "lodash": "^4.17.21",
-            "resolve-package-path": "^4.0.1",
-            "semver": "^7.3.5",
-            "typescript-memoize": "^1.0.1"
-          }
-        },
         "broccoli-funnel": {
           "version": "3.0.8",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
@@ -26594,9 +26807,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
+      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg=="
     },
     "@simple-dom/interface": {
       "version": "1.4.0",
@@ -31777,6 +31990,220 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
+        }
+      }
+    },
+    "ember-cli-deprecation-workflow": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-2.1.0.tgz",
+      "integrity": "sha512-Ay9P9iKMJdY4Gq5XPowh3HqqeAzLfwBRj1oB1ZKkDW1fryZQWBN4pZuRnjnB+3VWZjBnZif5e7Pacc7YNW9hWg==",
+      "requires": {
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-plugin": "^4.0.5",
+        "ember-cli-htmlbars": "^5.3.2"
+      },
+      "dependencies": {
+        "async-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.3",
+            "istextorbinary": "^2.5.1",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "rsvp": "^4.8.5",
+            "username-sync": "^1.0.2"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+          "requires": {
+            "array-equal": "^1.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+          "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+          "requires": {
+            "broccoli-plugin": "^4.0.2",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "broccoli-persistent-filter": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
+          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+          "requires": {
+            "async-disk-cache": "^2.0.0",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^4.0.3",
+            "fs-tree-diff": "^2.0.0",
+            "hash-for-dep": "^1.5.0",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.0.1",
+            "sync-disk-cache": "^2.0.0"
+          },
+          "dependencies": {
+            "promise-map-series": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+              "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+              "requires": {
+                "rsvp": "^3.0.14"
+              }
+            },
+            "rsvp": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+            }
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
+          }
+        },
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "ember-cli-htmlbars": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
+          "requires": {
+            "@ember/edition-utils": "^1.2.0",
+            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+            "broccoli-debug": "^0.6.5",
+            "broccoli-persistent-filter": "^3.1.2",
+            "broccoli-plugin": "^4.0.3",
+            "common-tags": "^1.8.0",
+            "ember-cli-babel-plugin-helpers": "^1.1.1",
+            "ember-cli-version-checker": "^5.1.2",
+            "fs-tree-diff": "^2.0.1",
+            "hash-for-dep": "^1.5.1",
+            "heimdalljs-logger": "^0.1.10",
+            "json-stable-stringify": "^1.0.1",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1",
+            "strip-bom": "^4.0.0",
+            "walk-sync": "^2.2.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "istextorbinary": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.2.0",
+            "textextensions": "^2.5.0"
+          }
+        },
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "promise-map-series": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA=="
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "sync-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.6",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "username-sync": "^1.0.2"
+          }
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "d3-transition": "^3.0.0",
     "ember-auto-import": "^2.2.4",
     "ember-cli-babel": "^7.26.6",
+    "ember-cli-deprecation-workflow": "^2.1.0",
     "ember-cli-htmlbars": "^6.0.0",
     "ember-cli-sass": "^10.0.0",
     "ember-concurrency": "^2.0.0",

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -1,0 +1,8 @@
+/* global window */
+
+window.deprecationWorkflow = window.deprecationWorkflow || {};
+window.deprecationWorkflow.config = {
+  workflow: [
+    { handler: 'silence', matchId: 'ember-modifier.use-destroyables' },
+  ],
+};


### PR DESCRIPTION
switch to the new destroyable methods while at it. 

deprecations are emitted out of the resize modifiers plugin, which will need to be update to latest ember-modifier plugin in order for the warnings to disappear. until that happens, we'll suppress those deprecation warnings.