### PR TITLE
Fix Tagging Workflow

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -21,6 +21,14 @@ jobs:
         git config user.name Zorgbort
         git config user.email info@iliosproject.org
     - name: Increment Version
-      run: npm version ${{ github.event.inputs.releaseType }}
+      run: npm version -w ember-simple-charts ${{ github.event.inputs.releaseType }}
+    - run: |
+        NEW_TAG=`node -p "require('./packages/ember-simple-charts/package.json').version"`
+        echo ${NEW_TAG}
+        echo "new_tag=${NEW_TAG}" >> $GITHUB_ENV
+    - name: Tag Version
+      run: |
+        git commit -a -m "${{env.new_tag}}"
+        git tag ${{env.new_tag}} -m "Tagging the ${{env.new_tag}} ${{ github.event.inputs.releaseType }} release"
     - name: Push Changes
       run: git push --follow-tags


### PR DESCRIPTION
The only thing we want to tag here is the addon, unfortunately npm doesn't make that super easy so we have to increment the workspace version and then extract that new version and use it to create a tag.