### PR TITLE
Widen supported ember range

### DIFF
--- a/packages/ember-simple-charts/package.json
+++ b/packages/ember-simple-charts/package.json
@@ -83,7 +83,7 @@
     "webpack": "^5.78.0"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0"
+    "ember-source": ">= 4.8.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18",


### PR DESCRIPTION
This prevented working with ember 5.x, which we very much support.