### PR TITLE
Ignore blueprint dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,58 +5,15 @@ updates:
   schedule:
     interval: weekly
   ignore:
+  - dependency-name: "@babel/eslint-parser"
+  - dependency-name: "@babel/plugin-proposal-decorators"
   - dependency-name: "@ember/optional-features"
+  - dependency-name: "@ember/string"
   - dependency-name: "@ember/test-helpers"
-  - dependency-name: "@embroider/test-setup"
   - dependency-name: "@glimmer/component"
   - dependency-name: "@glimmer/tracking"
-  - dependency-name: babel-eslint
   - dependency-name: broccoli-asset-rev
-  - dependency-name: ember-auto-import
-  - dependency-name: ember-cli
-  - dependency-name: ember-cli-app-version
-  - dependency-name: ember-cli-babel
-  - dependency-name: ember-cli-dependency-checker
-  - dependency-name: ember-cli-htmlbars
-  - dependency-name: ember-cli-inject-live-reload
-  - dependency-name: ember-cli-sri
-  - dependency-name: ember-cli-terser
-  - dependency-name: ember-export-application-global
-  - dependency-name: ember-fetch
-  - dependency-name: ember-load-initializers
-  - dependency-name: ember-page-title
-  - dependency-name: ember-qunit
-  - dependency-name: ember-resolver
-  - dependency-name: ember-source
-  - dependency-name: ember-source-channel-url
-  - dependency-name: ember-template-lint
-  - dependency-name: ember-try
-  - dependency-name: ember-welcome-page
-  - dependency-name: eslint
-  - dependency-name: eslint-config-prettier
-  - dependency-name: eslint-plugin-ember
-  - dependency-name: eslint-plugin-node
-  - dependency-name: eslint-plugin-prettier
-  - dependency-name: eslint-plugin-qunit
-  - dependency-name: loader.js
-  - dependency-name: npm-run-all
-  - dependency-name: prettier
-  - dependency-name: qunit
-  - dependency-name: qunit-dom
-  - dependency-name: webpack
-
-- package-ecosystem: npm
-  directory: "/packages/docs"
-  schedule:
-    interval: weekly
-  ignore:
-  - dependency-name: "@ember/optional-features"
-  - dependency-name: "@ember/test-helpers"
-  - dependency-name: "@embroider/test-setup"
-  - dependency-name: "@glimmer/component"
-  - dependency-name: "@glimmer/tracking"
-  - dependency-name: babel-eslint
-  - dependency-name: broccoli-asset-rev
+  - dependency-name: concurrently
   - dependency-name: ember-auto-import
   - dependency-name: ember-cli
   - dependency-name: ember-cli-app-version
@@ -67,40 +24,95 @@ updates:
   - dependency-name: ember-cli-sri
   - dependency-name: ember-cli-terser
   - dependency-name: ember-data
-  - dependency-name: ember-export-application-global
   - dependency-name: ember-fetch
   - dependency-name: ember-load-initializers
+  - dependency-name: ember-modifier
   - dependency-name: ember-page-title
   - dependency-name: ember-qunit
   - dependency-name: ember-resolver
   - dependency-name: ember-source
-  - dependency-name: ember-source-channel-url
   - dependency-name: ember-template-lint
-  - dependency-name: ember-try
   - dependency-name: ember-welcome-page
   - dependency-name: eslint
   - dependency-name: eslint-config-prettier
   - dependency-name: eslint-plugin-ember
-  - dependency-name: eslint-plugin-node
+  - dependency-name: eslint-plugin-n
   - dependency-name: eslint-plugin-prettier
   - dependency-name: eslint-plugin-qunit
   - dependency-name: loader.js
-  - dependency-name: npm-run-all
   - dependency-name: prettier
   - dependency-name: qunit
   - dependency-name: qunit-dom
+  - dependency-name: stylelint
+  - dependency-name: stylelint-config-standard
+  - dependency-name: stylelint-prettier
+  - dependency-name: tracked-built-ins
+  - dependency-name: webpack
+
+- package-ecosystem: npm
+  directory: "/packages/docs"
+  schedule:
+    interval: weekly
+  ignore:
+  - dependency-name: "@babel/eslint-parser"
+  - dependency-name: "@babel/plugin-proposal-decorators"
+  - dependency-name: "@ember/optional-features"
+  - dependency-name: "@ember/string"
+  - dependency-name: "@ember/test-helpers"
+  - dependency-name: "@glimmer/component"
+  - dependency-name: "@glimmer/tracking"
+  - dependency-name: broccoli-asset-rev
+  - dependency-name: concurrently
+  - dependency-name: ember-auto-import
+  - dependency-name: ember-cli
+  - dependency-name: ember-cli-app-version
+  - dependency-name: ember-cli-babel
+  - dependency-name: ember-cli-dependency-checker
+  - dependency-name: ember-cli-htmlbars
+  - dependency-name: ember-cli-inject-live-reload
+  - dependency-name: ember-cli-sri
+  - dependency-name: ember-cli-terser
+  - dependency-name: ember-data
+  - dependency-name: ember-fetch
+  - dependency-name: ember-load-initializers
+  - dependency-name: ember-modifier
+  - dependency-name: ember-page-title
+  - dependency-name: ember-qunit
+  - dependency-name: ember-resolver
+  - dependency-name: ember-source
+  - dependency-name: ember-template-lint
+  - dependency-name: ember-welcome-page
+  - dependency-name: eslint
+  - dependency-name: eslint-config-prettier
+  - dependency-name: eslint-plugin-ember
+  - dependency-name: eslint-plugin-n
+  - dependency-name: eslint-plugin-prettier
+  - dependency-name: eslint-plugin-qunit
+  - dependency-name: loader.js
+  - dependency-name: prettier
+  - dependency-name: qunit
+  - dependency-name: qunit-dom
+  - dependency-name: stylelint
+  - dependency-name: stylelint-config-standard
+  - dependency-name: stylelint-prettier
+  - dependency-name: tracked-built-ins
   - dependency-name: webpack
 
 - package-ecosystem: npm
   directory: "/packages/ember-simple-charts"
   schedule:
-    interval: daily
+    interval: weekly
   ignore:
+  - dependency-name: "@babel/eslint-parser"
+  - dependency-name: "@babel/plugin-proposal-decorators"
   - dependency-name: "@ember/optional-features"
+  - dependency-name: "@ember/string"
+  - dependency-name: "@ember/test-helpers"
+  - dependency-name: "@embroider/test-setup"
   - dependency-name: "@glimmer/component"
   - dependency-name: "@glimmer/tracking"
-  - dependency-name: babel-eslint
   - dependency-name: broccoli-asset-rev
+  - dependency-name: concurrently
   - dependency-name: ember-auto-import
   - dependency-name: ember-cli
   - dependency-name: ember-cli-babel
@@ -109,20 +121,27 @@ updates:
   - dependency-name: ember-cli-inject-live-reload
   - dependency-name: ember-cli-sri
   - dependency-name: ember-cli-terser
-  - dependency-name: ember-export-application-global
   - dependency-name: ember-load-initializers
+  - dependency-name: ember-page-title
+  - dependency-name: ember-qunit
   - dependency-name: ember-resolver
   - dependency-name: ember-source
+  - dependency-name: ember-source-channel-url
   - dependency-name: ember-template-lint
+  - dependency-name: ember-try
   - dependency-name: eslint
   - dependency-name: eslint-config-prettier
   - dependency-name: eslint-plugin-ember
-  - dependency-name: eslint-plugin-node
+  - dependency-name: eslint-plugin-n
   - dependency-name: eslint-plugin-prettier
   - dependency-name: eslint-plugin-qunit
   - dependency-name: loader.js
-  - dependency-name: npm-run-all
   - dependency-name: prettier
+  - dependency-name: qunit
+  - dependency-name: qunit-dom
+  - dependency-name: stylelint
+  - dependency-name: stylelint-config-standard
+  - dependency-name: stylelint-prettier
   - dependency-name: webpack
 
 - package-ecosystem: github-actions


### PR DESCRIPTION
We don't really want to update these, better to stick with the blueprint versions.