### PR TITLE
Skip git checks when publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,15 +8,15 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
       - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --ignore-scripts
       - name: publish
-        run: pnpm publish --filter ember-simple-charts
+        run: pnpm publish --filter ember-simple-charts --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
We publish off of a tag and pnpm doesn't love that. We have to skip this check to get publishing to work