### PR TITLE
rebuilds lock file.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
         version: 3.3.2(ember-cli@5.9.0(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.6))
       ember-cli-deprecation-workflow:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.0))
+        version: 3.0.1(ember-source@5.9.0(@babel/core@7.24.8)(@glimmer/component@1.1.2(@babel/core@7.24.8))(rsvp@4.8.5)(webpack@5.92.0))
       ember-cli-inject-live-reload:
         specifier: ^2.1.0
         version: 2.1.0
@@ -10779,12 +10779,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-deprecation-workflow@3.0.1(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.0)):
+  ember-cli-deprecation-workflow@3.0.1(ember-source@5.9.0(@babel/core@7.24.8)(@glimmer/component@1.1.2(@babel/core@7.24.8))(rsvp@4.8.5)(webpack@5.92.0)):
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.24.8
       '@ember/string': 3.1.1
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
-      ember-source: 5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.0)
+      ember-cli-babel: 8.2.0(@babel/core@7.24.8)
+      ember-source: 5.9.0(@babel/core@7.24.8)(@glimmer/component@1.1.2(@babel/core@7.24.8))(rsvp@4.8.5)(webpack@5.92.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
was seeing

```bash
$ pnpm install
Scope: all 4 workspace projects
Lockfile is up to date, resolution step is skipped
 WARN  Broken lockfile: no entry for '@babel/core@7.24.7' in pnpm-lock.yaml
 ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  The lockfile is broken! Resolution step will be performed to fix it.
packages/ember-simple-charts             |  WARN  Could not find preferred package @babel/core@7.24.7 in lockfile
packages/ember-simple-charts             |  WARN  Could not find preferred package @babel/core@7.24.7 in lockfile
packages/ember-simple-charts             |  WARN  Could not find preferred package ember-cli-babel@8.2.0(@babel/core@7.24.7) in lockfile
packages/ember-simple-charts             |  WARN  Could not find preferred package ember-cli-babel@8.2.0(@babel/core@7.24.7) in lockfile
 WARN  32 deprecated subdependencies found: @babel/plugin-proposal-class-properties@7.18.6, @babel/plugin-proposal-private-methods@7.18.6, @babel/plugin-proposal-private-property-in-object@7.21.11, @babel/polyfill@7.12.1, @humanwhocodes/config-array@0.11.14, @humanwhocodes/object-schema@2.0.3, acorn-dynamic-import@3.0.0, are-we-there-yet@3.0.1, chokidar@2.1.8, consolidate@0.16.0, copy-concurrently@1.0.5, core-js@2.6.12, figgy-pudding@3.5.2, fs-write-stream-atomic@1.0.10, fsevents@1.2.13, gauge@4.0.4, glob@5.0.15, glob@7.2.3, glob@8.1.0, inflight@1.0.6, move-concurrently@1.0.1, npmlog@6.0.2, resolve-url@0.2.1, rimraf@2.6.3, rimraf@2.7.1, rimraf@3.0.2, sane@4.1.0, source-map-resolve@0.5.3, source-map-url@0.3.0, source-map-url@0.4.1, sourcemap-codec@1.4.8, urix@0.1.0
Already up to date
Progress: resolved 1637, reused 1635, downloaded 0, added 0, done
. prepare$ husky
└─ Done in 42ms
Done in 2.7s
```

regenerating the lock file fixed this.