### PR TITLE
improved class attribute conditional class spacing

### DIFF
--- a/ember-simple-charts/src/components/simple-chart-bar.hbs
+++ b/ember-simple-charts/src/components/simple-chart-bar.hbs
@@ -1,6 +1,6 @@
 <svg
-  xmlns="http://www.w3.org/2000/svg"
-  class="simple-chart-bar {{if this.loading "loading" "loaded"}}"
+  xmlns='http://www.w3.org/2000/svg'
+  class='simple-chart-bar{{if this.loading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}

--- a/ember-simple-charts/src/components/simple-chart-box.hbs
+++ b/ember-simple-charts/src/components/simple-chart-box.hbs
@@ -1,6 +1,6 @@
 <svg
-  xmlns="http://www.w3.org/2000/svg"
-  class="simple-chart-box {{if this.loading "loading" "loaded"}}"
+  xmlns='http://www.w3.org/2000/svg'
+  class='simple-chart-box{{if this.loading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}

--- a/ember-simple-charts/src/components/simple-chart-cluster.hbs
+++ b/ember-simple-charts/src/components/simple-chart-cluster.hbs
@@ -1,6 +1,6 @@
 <svg
-  xmlns="http://www.w3.org/2000/svg"
-  class="simple-chart-cluster {{if this.loading "loading" "loaded"}}"
+  xmlns='http://www.w3.org/2000/svg'
+  class='simple-chart-cluster{{if this.loading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}

--- a/ember-simple-charts/src/components/simple-chart-donut.hbs
+++ b/ember-simple-charts/src/components/simple-chart-donut.hbs
@@ -1,6 +1,6 @@
 <svg
-  xmlns="http://www.w3.org/2000/svg"
-  class="simple-chart-donut {{if this.loading "loading" "loaded"}}"
+  xmlns='http://www.w3.org/2000/svg'
+  class='simple-chart-donut{{if this.loading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}

--- a/ember-simple-charts/src/components/simple-chart-horz-bar.hbs
+++ b/ember-simple-charts/src/components/simple-chart-horz-bar.hbs
@@ -1,6 +1,6 @@
 <svg
-  xmlns="http://www.w3.org/2000/svg"
-  class="simple-chart-horz-bar {{if this.loading "loading" "loaded"}}"
+  xmlns='http://www.w3.org/2000/svg'
+  class='simple-chart-horz-bar{{if this.loading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}

--- a/ember-simple-charts/src/components/simple-chart-pack.hbs
+++ b/ember-simple-charts/src/components/simple-chart-pack.hbs
@@ -1,6 +1,6 @@
 <svg
-  xmlns="http://www.w3.org/2000/svg"
-  class="simple-chart-pack {{if this.loading "loading" "loaded"}}"
+  xmlns='http://www.w3.org/2000/svg'
+  class='simple-chart-pack{{if this.loading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}

--- a/ember-simple-charts/src/components/simple-chart-pie.hbs
+++ b/ember-simple-charts/src/components/simple-chart-pie.hbs
@@ -1,6 +1,6 @@
 <svg
-  xmlns="http://www.w3.org/2000/svg"
-  class="simple-chart-pie {{if this.loading "loading" "loaded"}}"
+  xmlns='http://www.w3.org/2000/svg'
+  class='simple-chart-pie{{if this.loading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}


### PR DESCRIPTION
Kind of a stylistic choice, but I think it reads better when looking at a `class` attribute on an element to only include the space if an N+1 class is added.

Before, no conditional: `class="base-class "`
Before, with conditional: `class="base-class cond-class1"`

After, no conditional: `class="base-class"`
After, with conditional: `class="base-class cond-class1"`