### PR TITLE
swapped out ember-try directive for ember-release scenario because of v6 bug

### DIFF
--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getChannelURL = require('ember-source-channel-url');
+// const getChannelURL = require('ember-source-channel-url');, see: https://github.com/emberjs/ember.js/issues/20777
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
@@ -27,7 +27,8 @@ module.exports = async function () {
         name: 'ember-release',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('release'),
+            // 'ember-source': await getChannelURL('release'), see: https://github.com/emberjs/ember.js/issues/20777
+            'ember-source': 'release',
           },
         },
       },


### PR DESCRIPTION
Refs https://github.com/ilios/ember-simple-charts/commit/c9ef3e414739691ffc464db4db80a1dc624be03d

Started seeing the same issue as the scenarios in the referenced commit for `ember-release`, so followed suit for it, too.