### PR TITLE
Improve Transition Completion

### DIFF
--- a/ember-simple-charts/src/components/simple-chart-donut.js
+++ b/ember-simple-charts/src/components/simple-chart-donut.js
@@ -61,6 +61,7 @@ export default class SimpleChartDonut extends Component {
       .attr('stroke', '#FFFFFF')
       .attr('fill', (d) => color(d.data.data));
 
+    let runningTransitions = 0;
     chart
       .selectAll('path.slicepath')
       .transition()
@@ -71,8 +72,14 @@ export default class SimpleChartDonut extends Component {
         const i = interpolate({ startAngle: 0, endAngle: 0 }, b);
         return (p) => createArc(i(p));
       })
+      .on('start', () => {
+        //as each segment is animated record it
+        runningTransitions++;
+      })
       .on('end', () => {
-        if (!(isDestroyed(this) || isDestroying(this))) {
+        // end runs once for each segment as it finishs
+        runningTransitions--;
+        if (!runningTransitions && !(isDestroyed(this) || isDestroying(this))) {
           this.loading = false;
         }
       });

--- a/ember-simple-charts/src/components/simple-chart-pie.js
+++ b/ember-simple-charts/src/components/simple-chart-pie.js
@@ -58,6 +58,7 @@ export default class SimpleChartPie extends Component {
       .attr('stroke', '#FFFFFF')
       .attr('fill', (d) => color(d.data.data));
 
+    let runningTransitions = 0;
     chart
       .selectAll('path.slicepath')
       .transition()
@@ -68,8 +69,14 @@ export default class SimpleChartPie extends Component {
         const i = interpolate({ startAngle: 0, endAngle: 0 }, b);
         return (p) => createArc(i(p));
       })
+      .on('start', () => {
+        //as each segment is animated record it
+        runningTransitions++;
+      })
       .on('end', () => {
-        if (!(isDestroyed(this) || isDestroying(this))) {
+        // end runs once for each segment as it finishs
+        runningTransitions--;
+        if (!runningTransitions && !(isDestroyed(this) || isDestroying(this))) {
           this.loading = false;
         }
       });


### PR DESCRIPTION
It turns out that the `end` event we were tracking here from D3 doesn't apply to the entire transition. Each section of the donut or pie is animated individually and end gets called for each one.

I've added a counter which gets incremented as each section animation starts and decremented when they finish. When there are none left we can go ahead and mark loading as complete and update the class to loaded.