### PR TITLE
Replace Loading Logic

### DIFF
--- a/ember-simple-charts/package.json
+++ b/ember-simple-charts/package.json
@@ -51,6 +51,7 @@
     "d3-shape": "^3.2.0",
     "d3-transition": "^3.0.1",
     "decorator-transforms": "^2.2.2",
+    "ember-async-data": "^1.0.3",
     "ember-concurrency": "^4.0.2",
     "ember-in-element-polyfill": "^1.0.1",
     "ember-on-resize-modifier": "^2.0.2",

--- a/ember-simple-charts/src/components/simple-chart-donut.hbs
+++ b/ember-simple-charts/src/components/simple-chart-donut.hbs
@@ -1,6 +1,6 @@
 <svg
   xmlns='http://www.w3.org/2000/svg'
-  class='simple-chart-donut{{if this.loading " loading" " loaded"}}'
+  class='simple-chart-donut{{if this.isLoading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}

--- a/ember-simple-charts/src/components/simple-chart-pie.hbs
+++ b/ember-simple-charts/src/components/simple-chart-pie.hbs
@@ -1,6 +1,6 @@
 <svg
   xmlns='http://www.w3.org/2000/svg'
-  class='simple-chart-pie{{if this.loading " loading" " loaded"}}'
+  class='simple-chart-pie{{if this.isLoading " loading" " loaded"}}'
   height={{@containerHeight}}
   width={{@containerWidth}}
   {{did-update this.draw @containerHeight @containerWidth @data}}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       decorator-transforms:
         specifier: ^2.2.2
         version: 2.3.0(@babel/core@7.26.0)
+      ember-async-data:
+        specifier: ^1.0.3
+        version: 1.0.3(ember-source@6.0.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1))
       ember-concurrency:
         specifier: ^4.0.2
         version: 4.0.2(@babel/core@7.26.0)(@glimmer/tracking@1.1.2)(ember-source@6.0.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1))
@@ -3455,6 +3458,11 @@ packages:
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
+  ember-async-data@1.0.3:
+    resolution: {integrity: sha512-54OtoQwNi+/ZvPOVuT4t8fcHR9xL8N7kBydzcZSo6BIEsLYeXPi3+jUR8niWjfjXXhKlJ8EWXR0lTeHleTrxbw==}
+    peerDependencies:
+      ember-source: '>=4.8.4'
 
   ember-auto-import@1.12.2:
     resolution: {integrity: sha512-gLqML2k77AuUiXxWNon1FSzuG1DV7PEPpCLCU5aJvf6fdL6rmFfElsZRh+8ELEB/qP9dT+LHjNEunVzd2dYc8A==}
@@ -11535,6 +11543,14 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  ember-async-data@1.0.3(ember-source@6.0.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1)):
+    dependencies:
+      '@ember/test-waiters': 3.1.0
+      '@embroider/addon-shim': 1.9.0
+      ember-source: 6.0.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - supports-color
 
   ember-auto-import@1.12.2:
     dependencies:


### PR DESCRIPTION
Still not getting a reliable response from our loading indicator and causing percy to shoot too soon. Instead we can store the promise when we create a transition that will resolve when it is complete. If that promise isn't set yet, or isn't resolved we're in a 'loading' state.

Had the added benefit of hiding the defensive programming around a destroyed component. When the component is destroyed this getter won't fire anyway.