### PR TITLE
Restore Check for Zero Size

### DIFF
--- a/ember-simple-charts/src/components/simple-chart-cluster.js
+++ b/ember-simple-charts/src/components/simple-chart-cluster.js
@@ -25,6 +25,9 @@ export default class SimpleChartCluster extends Component {
         containerWidth,
       ],
     ) => {
+      if (!containerHeight || !containerWidth) {
+        return;
+      }
       this.loading = true;
       const height = Math.min(containerHeight, containerWidth) || 0;
       const width = Math.min(containerHeight, containerWidth) || 0;

--- a/ember-simple-charts/src/components/simple-chart-donut.js
+++ b/ember-simple-charts/src/components/simple-chart-donut.js
@@ -44,6 +44,9 @@ export default class SimpleChartDonut extends Component {
         containerWidth,
       ],
     ) => {
+      if (!containerHeight || !containerWidth) {
+        return;
+      }
       this.loadingPromise = null;
       const height = Math.min(containerHeight, containerWidth) || 0;
       const width = Math.min(containerHeight, containerWidth) || 0;

--- a/ember-simple-charts/src/components/simple-chart-pack.js
+++ b/ember-simple-charts/src/components/simple-chart-pack.js
@@ -25,6 +25,9 @@ export default class SimpleChartPack extends Component {
         containerWidth,
       ],
     ) => {
+      if (!containerHeight || !containerWidth) {
+        return;
+      }
       this.loading = true;
       const height = Math.min(containerHeight, containerWidth) || 0;
       const width = Math.min(containerHeight, containerWidth) || 0;

--- a/ember-simple-charts/src/components/simple-chart-pie.js
+++ b/ember-simple-charts/src/components/simple-chart-pie.js
@@ -44,6 +44,9 @@ export default class SimpleChartPie extends Component {
         containerWidth,
       ],
     ) => {
+      if (!containerHeight || !containerWidth) {
+        return;
+      }
       this.loadingPromise = null;
       const height = Math.min(containerHeight, containerWidth) || 0;
       const width = Math.min(containerHeight, containerWidth) || 0;

--- a/ember-simple-charts/src/components/simple-chart-tree.js
+++ b/ember-simple-charts/src/components/simple-chart-tree.js
@@ -25,6 +25,9 @@ export default class SimpleChartTree extends Component {
         containerWidth,
       ],
     ) => {
+      if (!containerHeight || !containerWidth) {
+        return;
+      }
       this.loading = true;
       const height = Math.min(containerHeight, containerWidth) || 0;
       const width = Math.min(containerHeight, containerWidth) || 0;


### PR DESCRIPTION
On initial render height and width are sometimes zero which causes D3 to calculate the internal state of these items incorrectly. We used to have this check, now we have it again.