### PR TITLE
Add SliceColor helper

### DIFF
--- a/ember-simple-charts/package.json
+++ b/ember-simple-charts/package.json
@@ -99,7 +99,8 @@
       "./components/simple-chart-pie.js": "./dist/_app_/components/simple-chart-pie.js",
       "./components/simple-chart-tooltip.js": "./dist/_app_/components/simple-chart-tooltip.js",
       "./components/simple-chart-tree.js": "./dist/_app_/components/simple-chart-tree.js",
-      "./components/simple-chart.js": "./dist/_app_/components/simple-chart.js"
+      "./components/simple-chart.js": "./dist/_app_/components/simple-chart.js",
+      "./helpers/slice-color.js": "./dist/_app_/helpers/slice-color.js"
     }
   }
 }

--- a/ember-simple-charts/package.json
+++ b/ember-simple-charts/package.json
@@ -99,8 +99,7 @@
       "./components/simple-chart-pie.js": "./dist/_app_/components/simple-chart-pie.js",
       "./components/simple-chart-tooltip.js": "./dist/_app_/components/simple-chart-tooltip.js",
       "./components/simple-chart-tree.js": "./dist/_app_/components/simple-chart-tree.js",
-      "./components/simple-chart.js": "./dist/_app_/components/simple-chart.js",
-      "./helpers/slice-color.js": "./dist/_app_/helpers/slice-color.js"
+      "./components/simple-chart.js": "./dist/_app_/components/simple-chart.js"
     }
   }
 }

--- a/ember-simple-charts/src/components/simple-chart-bar.js
+++ b/ember-simple-charts/src/components/simple-chart-bar.js
@@ -4,7 +4,7 @@ import { select } from 'd3-selection';
 import { scaleBand, scaleLinear, scaleSequential } from 'd3-scale';
 import { interpolateSinebow } from 'd3-scale-chromatic';
 import { modifier } from 'ember-modifier';
-import sliceColor from '../helpers/slice-color.js';
+import sliceColor from '../utils/slice-color.js';
 
 export default class SimpleChartBar extends Component {
   @tracked loading = true;
@@ -52,7 +52,7 @@ export default class SimpleChartBar extends Component {
           .data(data)
           .enter()
           .append('text')
-          .style('color', (d) => sliceColor.compute([d.data, color]))
+          .style('color', (d) => sliceColor(d.data, color))
           .style('font-size', '.8rem')
           .attr('text-anchor', 'middle')
           .attr('x', (d) => `${xScale(d.label) + xScale.bandwidth() / 2}%`)

--- a/ember-simple-charts/src/components/simple-chart-bar.js
+++ b/ember-simple-charts/src/components/simple-chart-bar.js
@@ -4,6 +4,7 @@ import { select } from 'd3-selection';
 import { scaleBand, scaleLinear, scaleSequential } from 'd3-scale';
 import { interpolateSinebow } from 'd3-scale-chromatic';
 import { modifier } from 'ember-modifier';
+import sliceColor from '../helpers/slice-color.js';
 
 export default class SimpleChartBar extends Component {
   @tracked loading = true;
@@ -51,18 +52,7 @@ export default class SimpleChartBar extends Component {
           .data(data)
           .enter()
           .append('text')
-          .style('color', (d) => {
-            const rgb = color(d.data);
-            //cut up rgb(1, 99, 245) into parts
-            const parts = rgb.substr(4).split(')')[0].split(',');
-            const r = parseInt(parts[0], 16);
-            const g = parseInt(parts[1], 16);
-            const b = parseInt(parts[2], 16);
-            //Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
-            const yiq = (r * 299 + g * 587 + b * 114) / 1000;
-
-            return yiq >= 256 ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
-          })
+          .style('color', (d) => sliceColor.compute([d.data, color]))
           .style('font-size', '.8rem')
           .attr('text-anchor', 'middle')
           .attr('x', (d) => `${xScale(d.label) + xScale.bandwidth() / 2}%`)

--- a/ember-simple-charts/src/components/simple-chart-donut.js
+++ b/ember-simple-charts/src/components/simple-chart-donut.js
@@ -9,7 +9,7 @@ import { easeLinear } from 'd3-ease';
 import { interpolate } from 'd3-interpolate';
 import { TrackedAsyncData } from 'ember-async-data';
 import { modifier } from 'ember-modifier';
-import sliceColor from '../helpers/slice-color.js';
+import sliceColor from '../utils/slice-color.js';
 
 export default class SimpleChartDonut extends Component {
   @tracked loadingPromise;
@@ -106,7 +106,7 @@ export default class SimpleChartDonut extends Component {
         const text = chart
           .selectAll('.slice')
           .append('text')
-          .style('color', (d) => sliceColor.compute([d.data.data, color]))
+          .style('color', (d) => sliceColor(d.data.data, color))
           .style('font-size', '.8rem')
           .attr(
             'transform',

--- a/ember-simple-charts/src/components/simple-chart-donut.js
+++ b/ember-simple-charts/src/components/simple-chart-donut.js
@@ -9,6 +9,7 @@ import { easeLinear } from 'd3-ease';
 import { interpolate } from 'd3-interpolate';
 import { TrackedAsyncData } from 'ember-async-data';
 import { modifier } from 'ember-modifier';
+import sliceColor from '../helpers/slice-color.js';
 
 export default class SimpleChartDonut extends Component {
   @tracked loadingPromise;
@@ -70,11 +71,13 @@ export default class SimpleChartDonut extends Component {
         .innerRadius(radius - 32);
 
       svg.selectAll('.chart').remove();
+
       const chart = svg
         .append('g')
         .attr('class', 'chart')
         //move the donut into the center of the chart
         .attr('transform', 'translate(' + width / 2 + ',' + height / 2 + ')');
+
       const path = chart
         .selectAll('.slice')
         .data(createPie(data))
@@ -103,18 +106,7 @@ export default class SimpleChartDonut extends Component {
         const text = chart
           .selectAll('.slice')
           .append('text')
-          .style('color', (d) => {
-            const rgb = color(d.data.data);
-            //cut up rgb(1, 99, 245) into parts
-            const parts = rgb.substr(4).split(')')[0].split(',');
-            const r = parseInt(parts[0], 16);
-            const g = parseInt(parts[1], 16);
-            const b = parseInt(parts[2], 16);
-            //Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
-            const yiq = (r * 299 + g * 587 + b * 114) / 1000;
-
-            return yiq >= 256 ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
-          })
+          .style('color', (d) => sliceColor.compute([d.data.data, color]))
           .style('font-size', '.8rem')
           .attr(
             'transform',

--- a/ember-simple-charts/src/components/simple-chart-horz-bar.js
+++ b/ember-simple-charts/src/components/simple-chart-horz-bar.js
@@ -5,6 +5,7 @@ import { select } from 'd3-selection';
 import { scaleBand, scaleLinear, scaleSequential } from 'd3-scale';
 import { interpolateSinebow } from 'd3-scale-chromatic';
 import { modifier } from 'ember-modifier';
+import sliceColor from '../helpers/slice-color.js';
 
 export default class SimpleChartHorzBar extends Component {
   @tracked loading = true;
@@ -52,18 +53,7 @@ export default class SimpleChartHorzBar extends Component {
           .data(data)
           .enter()
           .append('text')
-          .style('color', (d) => {
-            const rgb = color(d.data);
-            //cut up rgb(1, 99, 245) into parts
-            const parts = rgb.substr(4).split(')')[0].split(',');
-            const r = parseInt(parts[0], 16);
-            const g = parseInt(parts[1], 16);
-            const b = parseInt(parts[2], 16);
-            //Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
-            const yiq = (r * 299 + g * 587 + b * 114) / 1000;
-
-            return yiq >= 256 ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
-          })
+          .style('color', (d) => sliceColor.compute([d.data, color]))
           .style('font-size', '.8rem')
           .attr('text-anchor', 'end')
           .attr('text-align', 'right')

--- a/ember-simple-charts/src/components/simple-chart-horz-bar.js
+++ b/ember-simple-charts/src/components/simple-chart-horz-bar.js
@@ -5,7 +5,7 @@ import { select } from 'd3-selection';
 import { scaleBand, scaleLinear, scaleSequential } from 'd3-scale';
 import { interpolateSinebow } from 'd3-scale-chromatic';
 import { modifier } from 'ember-modifier';
-import sliceColor from '../helpers/slice-color.js';
+import sliceColor from '../utils/slice-color.js';
 
 export default class SimpleChartHorzBar extends Component {
   @tracked loading = true;
@@ -53,7 +53,7 @@ export default class SimpleChartHorzBar extends Component {
           .data(data)
           .enter()
           .append('text')
-          .style('color', (d) => sliceColor.compute([d.data, color]))
+          .style('color', (d) => sliceColor(d.data, color))
           .style('font-size', '.8rem')
           .attr('text-anchor', 'end')
           .attr('text-align', 'right')

--- a/ember-simple-charts/src/components/simple-chart-pie.js
+++ b/ember-simple-charts/src/components/simple-chart-pie.js
@@ -9,7 +9,7 @@ import { easeLinear } from 'd3-ease';
 import { interpolate } from 'd3-interpolate';
 import { TrackedAsyncData } from 'ember-async-data';
 import { modifier } from 'ember-modifier';
-import sliceColor from '../helpers/slice-color.js';
+import sliceColor from '../utils/slice-color.js';
 
 export default class SimpleChartPie extends Component {
   @tracked loadingPromise;
@@ -101,7 +101,7 @@ export default class SimpleChartPie extends Component {
         const text = chart
           .selectAll('.slice')
           .append('text')
-          .style('color', (d) => sliceColor.compute([d.data.data, color]))
+          .style('color', (d) => sliceColor(d.data.data, color))
           .style('font-size', '.8rem')
           .attr(
             'transform',

--- a/ember-simple-charts/src/components/simple-chart-pie.js
+++ b/ember-simple-charts/src/components/simple-chart-pie.js
@@ -9,6 +9,7 @@ import { easeLinear } from 'd3-ease';
 import { interpolate } from 'd3-interpolate';
 import { TrackedAsyncData } from 'ember-async-data';
 import { modifier } from 'ember-modifier';
+import sliceColor from '../helpers/slice-color.js';
 
 export default class SimpleChartPie extends Component {
   @tracked loadingPromise;
@@ -100,18 +101,7 @@ export default class SimpleChartPie extends Component {
         const text = chart
           .selectAll('.slice')
           .append('text')
-          .style('color', (d) => {
-            const rgb = color(d.data.data);
-            //cut up rgb(1, 99, 245) into parts
-            const parts = rgb.substr(4).split(')')[0].split(',');
-            const r = parseInt(parts[0], 16);
-            const g = parseInt(parts[1], 16);
-            const b = parseInt(parts[2], 16);
-            //Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
-            const yiq = (r * 299 + g * 587 + b * 114) / 1000;
-
-            return yiq >= 256 ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
-          })
+          .style('color', (d) => sliceColor.compute([d.data.data, color]))
           .style('font-size', '.8rem')
           .attr(
             'transform',

--- a/ember-simple-charts/src/helpers/slice-color.js
+++ b/ember-simple-charts/src/helpers/slice-color.js
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function sliceColor([data, color]) {
+  const rgb = color(data);
+  const parts = rgb.substr(4).split(')')[0].split(',');
+  const r = parseInt(parts[0], 16);
+  const g = parseInt(parts[1], 16);
+  const b = parseInt(parts[2], 16);
+  // Thanks to https://24ways.org/2010/calculating-color-contrast for this formula
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+
+  return yiq >= 256 ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
+});

--- a/ember-simple-charts/src/utils/slice-color.js
+++ b/ember-simple-charts/src/utils/slice-color.js
@@ -1,6 +1,4 @@
-import { helper } from '@ember/component/helper';
-
-export default helper(function sliceColor([data, color]) {
+export default function sliceColor(data, color) {
   const rgb = color(data);
   const parts = rgb.substr(4).split(')')[0].split(',');
   const r = parseInt(parts[0], 16);
@@ -10,4 +8,4 @@ export default helper(function sliceColor([data, color]) {
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
 
   return yiq >= 256 ? 'rgb(0, 0, 0)' : 'rgb(255, 255, 255)';
-});
+}


### PR DESCRIPTION
Helps clean up redundant code to determine the slice color in `Bar`, `Donut`, `HorzBar`, and `Pie` chart types