### PR TITLE
Fixed YIQ contrast function for text color

### DIFF
--- a/ember-simple-charts/src/components/simple-chart-bar.js
+++ b/ember-simple-charts/src/components/simple-chart-bar.js
@@ -52,7 +52,7 @@ export default class SimpleChartBar extends Component {
           .data(data)
           .enter()
           .append('text')
-          .style('color', (d) => sliceColor(d.data, color))
+          .style('fill', (d) => sliceColor(d.data, color))
           .style('font-size', '.8rem')
           .attr('text-anchor', 'middle')
           .attr('x', (d) => `${xScale(d.label) + xScale.bandwidth() / 2}%`)

--- a/ember-simple-charts/src/components/simple-chart-donut.js
+++ b/ember-simple-charts/src/components/simple-chart-donut.js
@@ -106,7 +106,7 @@ export default class SimpleChartDonut extends Component {
         const text = chart
           .selectAll('.slice')
           .append('text')
-          .style('color', (d) => sliceColor(d.data.data, color))
+          .style('fill', (d) => sliceColor(d.data.data, color))
           .style('font-size', '.8rem')
           .attr(
             'transform',

--- a/ember-simple-charts/src/components/simple-chart-horz-bar.js
+++ b/ember-simple-charts/src/components/simple-chart-horz-bar.js
@@ -53,7 +53,7 @@ export default class SimpleChartHorzBar extends Component {
           .data(data)
           .enter()
           .append('text')
-          .style('color', (d) => sliceColor(d.data, color))
+          .style('fill', (d) => sliceColor(d.data, color))
           .style('font-size', '.8rem')
           .attr('text-anchor', 'end')
           .attr('text-align', 'right')

--- a/ember-simple-charts/src/components/simple-chart-pie.js
+++ b/ember-simple-charts/src/components/simple-chart-pie.js
@@ -101,7 +101,7 @@ export default class SimpleChartPie extends Component {
         const text = chart
           .selectAll('.slice')
           .append('text')
-          .style('color', (d) => sliceColor(d.data.data, color))
+          .style('fill', (d) => sliceColor(d.data.data, color))
           .style('font-size', '.8rem')
           .attr(
             'transform',

--- a/test-app/tests/integration/components/simple-chart-bar-test.js
+++ b/test-app/tests/integration/components/simple-chart-bar-test.js
@@ -53,16 +53,16 @@ module('Integration | Component | simple chart bar', function (hooks) {
     assert.dom(text3).hasText('400');
     assert.dom(text4).hasText('500');
     assert.ok(
-      find(text1).getAttribute('style').includes('color: rgb(255, 255, 255);'),
+      find(text1).getAttribute('style').includes('fill: rgb(255, 255, 255);'),
     );
     assert.ok(
-      find(text2).getAttribute('style').includes('color: rgb(0, 0, 0);'),
+      find(text2).getAttribute('style').includes('fill: rgb(0, 0, 0);'),
     );
     assert.ok(
-      find(text3).getAttribute('style').includes('color: rgb(255, 255, 255);'),
+      find(text3).getAttribute('style').includes('fill: rgb(255, 255, 255);'),
     );
     assert.ok(
-      find(text4).getAttribute('style').includes('color: rgb(255, 255, 255);'),
+      find(text4).getAttribute('style').includes('fill: rgb(255, 255, 255);'),
     );
     assert.dom(`${rect1} desc`).hasText('The value is 300.');
   });

--- a/test-app/tests/integration/components/simple-chart-horz-bar-test.js
+++ b/test-app/tests/integration/components/simple-chart-horz-bar-test.js
@@ -65,26 +65,22 @@ module('Integration | Component | simple chart horz bar', function (hooks) {
     assert.dom(text5).hasText('Joe');
     assert.dom(text6).hasText('Kelly');
     assert.dom(text7).hasText('Jason');
+    assert.ok(find(text1).getAttribute('style').includes('fill: rgb(0, 0, 0)'));
     assert.ok(
-      find(text1).getAttribute('style').includes('color: rgb(0, 0, 0)'),
+      find(text2).getAttribute('style').includes('fill: rgb(255, 255, 255)'),
     );
     assert.ok(
-      find(text2).getAttribute('style').includes('color: rgb(255, 255, 255)'),
+      find(text3).getAttribute('style').includes('fill: rgb(255, 255, 255)'),
     );
     assert.ok(
-      find(text3).getAttribute('style').includes('color: rgb(255, 255, 255)'),
+      find(text4).getAttribute('style').includes('fill: rgb(255, 255, 255)'),
+    );
+    assert.ok(find(text5).getAttribute('style').includes('fill: rgb(0, 0, 0)'));
+    assert.ok(
+      find(text6).getAttribute('style').includes('fill: rgb(255, 255, 255)'),
     );
     assert.ok(
-      find(text4).getAttribute('style').includes('color: rgb(255, 255, 255)'),
-    );
-    assert.ok(
-      find(text5).getAttribute('style').includes('color: rgb(0, 0, 0)'),
-    );
-    assert.ok(
-      find(text6).getAttribute('style').includes('color: rgb(255, 255, 255)'),
-    );
-    assert.ok(
-      find(text7).getAttribute('style').includes('color: rgb(255, 255, 255)'),
+      find(text7).getAttribute('style').includes('fill: rgb(255, 255, 255)'),
     );
     assert
       .dom(`${rect1} desc`)

--- a/test-app/tests/integration/components/simple-chart-pie-test.js
+++ b/test-app/tests/integration/components/simple-chart-pie-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | simple chart pie', function (hooks) {
     assert.dom(`${section1} text`).hasAttribute('text-anchor', 'middle');
     assert
       .dom(`${section1} text`)
-      .hasAttribute('style', 'color: rgb(255, 255, 255); font-size: 0.8rem;');
+      .hasAttribute('style', 'fill: rgb(255, 255, 255); font-size: 0.8rem;');
     assert.dom(`${section1} text`).hasText('Totally Cool');
     assert.dom(`${section1} desc`).hasText('This is totally cool.');
 
@@ -65,7 +65,7 @@ module('Integration | Component | simple chart pie', function (hooks) {
     assert.dom(`${section2} text`).hasAttribute('text-anchor', 'middle');
     assert
       .dom(`${section2} text`)
-      .hasAttribute('style', 'color: rgb(0, 0, 0); font-size: 0.8rem;');
+      .hasAttribute('style', 'fill: rgb(0, 0, 0); font-size: 0.8rem;');
     assert.dom(`${section2} text`).hasText('Way Cool');
     assert.dom(`${section2} desc`).hasText('This is way cool.');
 
@@ -80,7 +80,7 @@ module('Integration | Component | simple chart pie', function (hooks) {
     assert.dom(`${section3} text`).hasAttribute('text-anchor', 'middle');
     assert
       .dom(`${section3} text`)
-      .hasAttribute('style', 'color: rgb(255, 255, 255); font-size: 0.8rem;');
+      .hasAttribute('style', 'fill: rgb(255, 255, 255); font-size: 0.8rem;');
     assert.dom(`${section3} text`).hasText('Cucumber Cool');
     assert.dom(`${section3} desc`).hasText('This is cool as cucumber.');
 
@@ -98,7 +98,7 @@ module('Integration | Component | simple chart pie', function (hooks) {
     assert.dom(`${section4} text`).hasAttribute('text-anchor', 'middle');
     assert
       .dom(`${section4} text`)
-      .hasAttribute('style', 'color: rgb(255, 255, 255); font-size: 0.8rem;');
+      .hasAttribute('style', 'fill: rgb(255, 255, 255); font-size: 0.8rem;');
     assert.dom(`${section4} text`).hasText('So Cool');
     assert.dom(`${section4} desc`).hasText('This is so cool.');
   });


### PR DESCRIPTION
Fixes #1245 

The attribute for changing the color of text is `fill`, not `color`, so I swapped it for the charts that use text.