### PR TITLE
Pin @ember/test-helpers Version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.9",
     "@ember/optional-features": "^2.2.0",
-    "@ember/test-helpers": "^4.0.4",
+    "@ember/test-helpers": "4.0.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@percy/cli": "^1.30.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@ember/test-helpers':
-        specifier: ^4.0.4
+        specifier: 4.0.4
         version: 4.0.4(@babel/core@7.26.9)(ember-source@6.0.1(@glimmer/component@1.1.2(@babel/core@7.26.9))(rsvp@4.8.5)(webpack@5.97.1))
       '@glimmer/component':
         specifier: ^1.1.2
@@ -310,7 +310,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       '@ember/test-helpers':
-        specifier: ^4.0.4
+        specifier: 4.0.4
         version: 4.0.4(@babel/core@7.26.9)(ember-source@6.0.1(@glimmer/component@1.1.2(@babel/core@7.26.9))(rsvp@4.8.5)(webpack@5.97.1))
       '@embroider/test-setup':
         specifier: ^3.0.1
@@ -7770,18 +7770,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.18.1:
     resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
     engines: {node: '>=10.0.0'}
@@ -8694,7 +8682,7 @@ snapshots:
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.9.0
-      '@embroider/macros': 1.16.10
+      '@embroider/macros': 1.16.11
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.26.9)
       dom-element-descriptors: 0.5.1
@@ -17326,8 +17314,6 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.17.1: {}
-
-  ws@8.18.0: {}
 
   ws@8.18.1: {}
 

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -30,7 +30,7 @@
     "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember/optional-features": "^2.2.0",
     "@ember/string": "^4.0.0",
-    "@ember/test-helpers": "^4.0.4",
+    "@ember/test-helpers": "4.0.4",
     "@embroider/test-setup": "^3.0.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
This 4.0.5 release widens the dependency range for @ember/test-waiters which ember-async-data isn't ready for. Locking the version for now while we await a resolution.