### PR TITLE
Turn on opt-out text-outline for HorzBar type

### DIFF
--- a/ember-simple-charts/src/components/simple-chart-horz-bar.js
+++ b/ember-simple-charts/src/components/simple-chart-horz-bar.js
@@ -15,7 +15,10 @@ export default class SimpleChartHorzBar extends Component {
   }
 
   paint = modifier(
-    (element, [data, isIcon, isClickable, hover, leave, onClick]) => {
+    (
+      element,
+      [data, isIcon, isClickable, hover, leave, onClick, textIsNotOutlined],
+    ) => {
       this.loading = true;
       const svg = select(element);
       const values = data.map((d) => d.data);
@@ -60,35 +63,35 @@ export default class SimpleChartHorzBar extends Component {
           .attr('dominant-baseline', 'central')
           .attr('y', (d) => `${yScale(d.label) + yScale.bandwidth() / 2}%`)
           .attr('x', (d) => `${xScale(d.data) - 3}%`)
-          .text((d) => d.label);
-        // Adding outline to horiz-bar text has incorrect vertical-alignment cross-browser, so turned off for now
-        // .each(function () {
-        //   if (!textIsNotOutlined) {
-        //     select(this)
-        //       .append('tspan')
-        //       .attr('class', 'text-outline')
-        //       .attr('fill', (d) => sliceColor(d.data, color, true))
-        //       .attr('stroke', (d) => sliceColor(d.data, color, true))
-        //       .attr('stroke-width', '3px')
-        //       .attr('stroke-linejoin', 'round')
-        //       .attr(
-        //         'y',
-        //         (d) => `${yScale(d.label) + yScale.bandwidth() / 2}%`,
-        //       )
-        //       .attr('dy', '4.5')
-        //       .text((d) => d.label)
-        //       .append('tspan')
-        //       .attr(
-        //         'y',
-        //         (d) => `${yScale(d.label) + yScale.bandwidth() / 2}%`,
-        //       )
-        //       .attr('x', (d) => `${xScale(d.data) - 3}%`)
-        //       .attr('dy', '0')
-        //       .text('\u200b');
+          .each(function () {
+            if (!textIsNotOutlined) {
+              select(this)
+                .append('tspan')
+                .attr('class', 'text-outline')
+                .attr('fill', (d) => sliceColor(d.data, color, true))
+                .attr('stroke', (d) => sliceColor(d.data, color, true))
+                .attr('stroke-width', '3px')
+                .attr('stroke-linejoin', 'round')
+                .attr(
+                  'y',
+                  (d) => `${yScale(d.label) + yScale.bandwidth() / 2}%`,
+                )
+                .attr('dy', '0')
+                .attr('dominant-baseline', 'central')
+                .text((d) => d.label)
+                .append('tspan')
+                .attr(
+                  'y',
+                  (d) => `${yScale(d.label) + yScale.bandwidth() / 2}%`,
+                )
+                .attr('x', (d) => `${xScale(d.data) - 3}%`)
+                .attr('dy', '0')
+                .attr('dominant-baseline', 'central')
+                .text('\u200b');
 
-        //     select(this).append((d) => document.createTextNode(d.label));
-        //   }
-        // });
+              select(this).append((d) => document.createTextNode(d.label));
+            }
+          });
 
         bars
           .selectAll('rect')


### PR DESCRIPTION
I tried nudging things around here and there, but I couldn't quite get a perfect "outline" effect to work for both Mozilla and Webkit rendering. This solution doesn't use any [Magic Numbers], at least.