### PR TITLE
bump setup-node action version, pnpm to v22, and use pnpx over npx

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -29,13 +29,16 @@ jobs:
       - name: Increment Version
         working-directory: ./ember-simple-charts
         run: pnpx versionup --level ${{ github.event.inputs.releaseType }}
+      - name: Format Package JSON
+        run: pnpm format
       - run: |
           NEW_TAG=`node -p "require('./ember-simple-charts/package.json').version"`
           echo ${NEW_TAG}
           echo "new_tag=${NEW_TAG}" >> $GITHUB_ENV
       - name: Tag Version
         run: |
-          git commit -a -m "${{env.new_tag}}"
+          git add ember-simple-charts/package.json
+          git commit -m "${{env.new_tag}}"
           git tag v${{env.new_tag}} -m "Tagging the v${{env.new_tag}} ${{ github.event.inputs.releaseType }} release"
       - name: Push Changes
         run: git push --follow-tags

--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -14,18 +14,21 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.ZORGBORT_TOKEN }}
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install
       - name: Validate releaseType
-        run: npx in-string-list ${{ github.event.inputs.releaseType }} major,minor,patch
+        run: pnpx in-string-list ${{ github.event.inputs.releaseType }} major,minor,patch
       - name: Setup Git
         run: |
           git config user.name Zorgbort
           git config user.email info@iliosproject.org
       - name: Increment Version
         working-directory: ./ember-simple-charts
-        run: npx versionup --level ${{ github.event.inputs.releaseType }}
+        run: pnpx versionup --level ${{ github.event.inputs.releaseType }}
       - run: |
           NEW_TAG=`node -p "require('./ember-simple-charts/package.json').version"`
           echo ${NEW_TAG}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "The Ilios Team (info@iliosproject.org)",
   "scripts": {
     "build": "pnpm --filter ember-simple-charts build",
+    "format": "pnpm run --parallel format",
     "lint": "pnpm --filter '*' lint",
     "lint:fix": "pnpm --filter '*' lint:fix",
     "prepare": "husky && pnpm build",


### PR DESCRIPTION
this is a partial realignment with the corresponding workflow definition in ilios/frontend.

for reference, please see https://github.com/ilios/frontend/commit/0ec2e365345b245d9041f0290307b9db06e81827